### PR TITLE
Fix authorization header not passed to proxy (fix #9)

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -22,6 +22,8 @@ location __PATH__/ {
     proxy_buffering off;
     fastcgi_param REMOTE_USER   $remote_user;
     client_max_body_size        50M;
+    more_set_input_headers      'Authorization: $http_authorization';
+    proxy_set_header            Authorization $http_authorization;
 
     # Force https
     if ($scheme = http) {


### PR DESCRIPTION
This fixes the login issue for me.
Unfortunately I can't really explain why the first line is needed, but without it `$http_authorization` is wrong (as in different from what the client sent).