### PR TITLE
Enhance security

### DIFF
--- a/conf/config.yml
+++ b/conf/config.yml
@@ -21,6 +21,6 @@ database: # for database see (configure database section)
 defaultuser: # on database creation, gotify creates an admin user
   name: __ADMINUSER__ # the username of the default user
   pass: __ADMINPASS__ # the password of the default user
-passstrength: 10 # the bcrypt password strength (higher = better but also slower)
+passstrength: 12 # the bcrypt password strength (higher = better but also slower)
 uploadedimagesdir: data/images # the directory for storing uploaded images
 pluginsdir: data/plugins # the directory where plugin resides

--- a/scripts/install
+++ b/scripts/install
@@ -139,7 +139,10 @@ ynh_store_file_checksum "$final_path/config.yml"
 # Set permissions to app files
 chown -R root: $final_path
 mkdir $final_path/data
+chown -R root:$app $final_path/*
+chmod -R 550 $final_path/*
 chown $app $final_path/data
+chmod 770 $final_path/data
 
 #=================================================
 # ADVERTISE SERVICE IN ADMIN PANEL
@@ -164,3 +167,4 @@ systemctl reload nginx
 
 systemctl start $app
 ynh_script_progression --message="Installation of $app completed" --last
+ynh_print_warn "Change the admin password after the first login or delete it in the config file (stored in plain text)"


### PR DESCRIPTION
1. The password submitted has to be change after the first login since it is stored in plain text (for the installation)
2. Files (config included) were world readable
3. Setting the work factor for Bcrypt to 12 (following OWASP recommendation)