### PR TITLE
fix hash for arm 2.0.16

### DIFF
--- a/conf/arm.src
+++ b/conf/arm.src
@@ -1,5 +1,5 @@
 SOURCE_URL=https://github.com/gotify/server/releases/download/v2.0.16/gotify-linux-arm-7.zip
-SOURCE_SUM=c0919fa83fadf6ffee12b14dd94c0662bff69e83c11f51f9f1228ac374f91bf0
+SOURCE_SUM=62cd54303a79af678a77b8591836851c31cebf83c48392fd149007ba39926691
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=false


### PR DESCRIPTION
It is the amd64 hash on the arm.src conf file