### PR TITLE
Remove CORS * header

### DIFF
--- a/conf/config.yml
+++ b/conf/config.yml
@@ -6,10 +6,6 @@ server:
     enabled: false # if https should be enabled
     redirecttohttps: false # redirect to https if site is accessed by http
 
-  responseheaders: # response headers are added to every response (default: none)
-    Access-Control-Allow-Origin: "*"
-    Access-Control-Allow-Methods: "GET,POST"
-
   stream:
     allowedorigins: # allowed origins for websocket connections (same origin is always allowed)
       - ".+.__DOMAIN__"


### PR DESCRIPTION
The header `Access-Control-Allow-Origin: * ` is never trusted by recent browsers because it is a recurrent error done by developers (leading to data exposure if it were trusted). We do not need to set authorized a CORS since the requests are send to the same origin.